### PR TITLE
added KindSignatures pragma to testsuite to fix GHC 7.10 build

### DIFF
--- a/tests/Data/IxSet/Typed/Tests.hs
+++ b/tests/Data/IxSet/Typed/Tests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, TemplateHaskell, OverlappingInstances, UndecidableInstances, TemplateHaskell, DataKinds, FlexibleInstances, MultiParamTypeClasses, TypeOperators #-}
+{-# LANGUAGE DeriveDataTypeable, TemplateHaskell, OverlappingInstances, UndecidableInstances, TemplateHaskell, DataKinds, FlexibleInstances, MultiParamTypeClasses, TypeOperators, KindSignatures #-}
 {-# OPTIONS_GHC -fdefer-type-errors -fno-warn-orphans #-}
 
 -- TODO (only if SYBWC is added again):


### PR DESCRIPTION
The test suite fails to build using GHC 7.10 without this flag. The `KindSignatures` flag was added in 6.12 or earlier, so it should not pose any backwards compatibility issues.