### PR TITLE
Implement errorTypeName for IxSet

### DIFF
--- a/src/Data/IxSet/Typed.hs
+++ b/src/Data/IxSet/Typed.hs
@@ -396,6 +396,7 @@ instance (Indexable ixs a, Read a) => Read (IxSet ixs a) where
 instance (Indexable ixs a, SafeCopy a) => SafeCopy (IxSet ixs a) where
   putCopy = contain . safePut . toList
   getCopy = contain $ fmap fromList safeGet
+  errorTypeName _ = "IxSet"
 
 instance (All NFData ixs, NFData a) => NFData (IxList ixs a) where
   rnf Nil        = ()


### PR DESCRIPTION
Improves SafeCopy error message.