### PR TITLE
Add project function

### DIFF
--- a/src/Data/IxSet/Typed.hs
+++ b/src/Data/IxSet/Typed.hs
@@ -183,6 +183,7 @@ module Data.IxSet.Typed
      flattenWithCalcs,
 
      -- * Debugging and optimization
+     project,
      stats
 )
 where
@@ -366,6 +367,12 @@ zipWithIxList' _ _          _          = error "Data.IxSet.Typed.zipWithIxList: 
   -- the line above is actually impossible by the types; it's just there
   -- to please avoid the warning resulting from the exhaustiveness check
 #endif
+
+-- | Project out the indices from a value of an 'Indexable' type.
+project :: forall proxy ixs ix a . (Indexable ixs a, IsIndexOf ix ixs) => proxy ixs -> a -> [ix]
+project _ = case access (indices :: IxList ixs a) :: Ix ix a of
+              Ix _ f -> f
+
 
 --------------------------------------------------------------------------
 -- Various instances for 'IxSet'

--- a/src/Data/IxSet/Typed.hs
+++ b/src/Data/IxSet/Typed.hs
@@ -184,6 +184,7 @@ module Data.IxSet.Typed
 
      -- * Debugging and optimization
      project,
+     getIndex,
      stats
 )
 where
@@ -372,6 +373,11 @@ zipWithIxList' _ _          _          = error "Data.IxSet.Typed.zipWithIxList: 
 project :: forall proxy ixs ix a . (Indexable ixs a, IsIndexOf ix ixs) => proxy ixs -> a -> [ix]
 project _ = case access (indices :: IxList ixs a) :: Ix ix a of
               Ix _ f -> f
+
+-- | Extract a single index map from an 'IxSet'.
+getIndex :: forall ixs ix a . (Indexable ixs a, IsIndexOf ix ixs) => IxSet ixs a -> Map ix (Set a)
+getIndex (IxSet _ ixs) = case access ixs of
+    Ix m _ -> m
 
 
 --------------------------------------------------------------------------

--- a/tests/Data/IxSet/Typed/Tests.hs
+++ b/tests/Data/IxSet/Typed/Tests.hs
@@ -12,6 +12,7 @@ import           Control.Exception
 import           Data.Data         (Data, Typeable)
 import           Data.IxSet.Typed  as IxSet
 import           Data.Maybe
+import           Data.Proxy        (Proxy(Proxy))
 import qualified Data.Set          as Set
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -240,6 +241,13 @@ funIndexes =
         3 @=? size (funSet @>=<= (3 :: Int, 7 :: Int))
     ]
 
+projectIndices :: TestTree
+projectIndices =
+  testGroup "project indices" $
+    [ testCase "projects out length" $
+        project (Proxy :: Proxy '[Int]) (S "abc") @=? [3 :: Int]
+    ]
+
 bigSet :: Int -> MultiIndexed
 bigSet n = fromList $
     [ MultiIndex string int integer maybe_int either_bool_char |
@@ -282,6 +290,7 @@ allTests =
       , multiIndexed
       , testTriple
       , funIndexes
+      , projectIndices
       ]
     , testGroup "properties" $
       [ sizeEqToListLength


### PR DESCRIPTION
Fixes #25. This makes it possible to retrieve the projection function contained within the `Ix` list.